### PR TITLE
支持 Token鉴权方式

### DIFF
--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -10,7 +10,9 @@
 #################################################
 
 # 全局变量表
-arPass=arMail=""
+arToken=""
+arPass=""
+arMail=""
 
 # 获得外网地址
 arIpAdress() {
@@ -30,7 +32,11 @@ arNslookup() {
 arApiPost() {
     local agent="AnripDdns/5.07(mail@anrip.com)"
     local inter="https://dnsapi.cn/${1:?'Info.Version'}"
-    local param="login_email=${arMail}&login_password=${arPass}&format=json&${2}"
+    if [ "x${arToken}" = "x" ]; then # undefine token
+        local param="login_email=${arMail}&login_password=${arPass}&format=json&${2}"
+    else
+        local param="login_token=${arToken}&format=json&${2}"
+    fi
     wget --quiet --no-check-certificate --output-document=- --user-agent=$agent --post-data $param $inter
 }
 


### PR DESCRIPTION
参见官方文档：https://support.dnspod.cn/Kb/showarticle/tsid/227/

后续新用户将全部使用 Token 来鉴权，具体时间会提前通知，也建议开发者们都采用 Token 来鉴权，不要再使用 “用户名 ＋ 密码” 的方式。

且Token 的生成是完全独立的，即使 Token 丢失，黑客也不知道用户的帐号和密码，万一 Token 泄漏，用户只需要登录 DNSPod 后台，将有安全问题的 Token 删除即可，极大的提高了帐号安全性。

Token 设置方式参见上方文档链接。