### PR TITLE
3个PR

### DIFF
--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -152,7 +152,7 @@ arApiPost() {
 # Update
 # arg: main domain  sub domain
 arDdnsUpdate() {
-    local domainID recordID recordRS recordCD myIP
+    local domainID recordID recordRS recordCD recordIP myIP
     # Get domain ID
     domainID=$(arApiPost "Domain.Info" "domain=${1}")
     domainID=$(echo $domainID | sed 's/.*{"id":"\([0-9]*\)".*/\1/')
@@ -165,15 +165,21 @@ arDdnsUpdate() {
     myIP=$(arIpAddress)
     recordRS=$(arApiPost "Record.Ddns" "domain_id=${domainID}&record_id=${recordID}&sub_domain=${2}&record_type=A&value=${myIP}&record_line=默认")
     recordCD=$(echo $recordRS | sed 's/.*{"code":"\([0-9]*\)".*/\1/')
+    recordIP=$(echo $recordRS | sed 's/.*,"value":"\([0-9\.]*\)".*/\1/')
 
     # Output IP
-    if [ "$recordCD" = "1" ]; then
-        echo $recordRS | sed 's/.*,"value":"\([0-9\.]*\)".*/\1/'
-        return 0
+    if [ "$recordIP" = "$myIP" ]; then
+        if [ "$recordCD" = "1" ]; then
+            echo $recordIP
+            return 0
+        fi
+        # Echo error message
+        echo $recordRS | sed 's/.*,"message":"\([^"]*\)".*/\1/'
+        return 1
+    else
+        echo "Update Failed! Please check your network."
+        return 1
     fi
-    # Echo error message
-    echo $recordRS | sed 's/.*,"message":"\([^"]*\)".*/\1/'
-    return 1
 }
 
 # DDNS Check
@@ -192,6 +198,9 @@ arDdnsCheck() {
             if [ $? -eq 0 ]; then
                 echo "postRS: ${postRS}"
                 return 0
+            else
+                echo ${postRS}
+                return 1
             fi
         fi
         echo "Last IP is the same as current IP!"

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -169,10 +169,11 @@ arDdnsUpdate() {
     # Output IP
     if [ "$recordCD" = "1" ]; then
         echo $recordRS | sed 's/.*,"value":"\([0-9\.]*\)".*/\1/'
-        return 1
+        return 0
     fi
     # Echo error message
     echo $recordRS | sed 's/.*,"message":"\([^"]*\)".*/\1/'
+    return 1
 }
 
 # DDNS Check
@@ -188,8 +189,8 @@ arDdnsCheck() {
         echo "lastIP: ${lastIP}"
         if [ "$lastIP" != "$hostIP" ]; then
             postRS=$(arDdnsUpdate $1 $2)
-            echo "postRS: ${postRS}"
-            if [ $? -ne 1 ]; then
+            if [ $? -eq 0 ]; then
+                echo "postRS: ${postRS}"
                 return 0
             fi
         fi

--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -127,10 +127,11 @@ arDdnsInfo() {
     case "$recordIP" in 
       [1-9][0-9]*)
         echo $recordIP
-        return 1
+        return 0
         ;;
       *)
         echo "Get Record Info Failed!"
+        return 1
         ;;
     esac
 }
@@ -180,17 +181,22 @@ arDdnsCheck() {
     local postRS
     local lastIP
     local hostIP=$(arIpAddress)
+    echo "Updating Domain: ${2}.${1}"
     echo "hostIP: ${hostIP}"
     lastIP=$(arDdnsInfo "$1 $2")
-    echo "lastIP: ${lastIP}"
-    if [ "$lastIP" != "$hostIP" ]; then
-        postRS=$(arDdnsUpdate $1 $2)
-        echo "postRS: ${postRS}"
-        if [ $? -ne 1 ]; then
-            return 0
+    if [ $? -eq 0 ]; then
+        echo "lastIP: ${lastIP}"
+        if [ "$lastIP" != "$hostIP" ]; then
+            postRS=$(arDdnsUpdate $1 $2)
+            echo "postRS: ${postRS}"
+            if [ $? -ne 1 ]; then
+                return 0
+            fi
         fi
+        echo "Last IP is the same as current IP!"
+        return 1
     fi
-    echo "Last IP is the same as current IP!"
+    echo ${lastIP}
     return 1
 }
 


### PR DESCRIPTION
第一个是昨天我写的一些漏洞，获取记录IP错误的话返回的警告同样会跟hostIP不一样。
第二个是你上传IP之后先输出了一条log会导致$?永远都是0，所以应该先判断返回再输出log。
第三个是确定上传的IP跟上传之后返回结果的IP一致。因为我测试过value那里随便写些什么都一样会提示成功上传，看文档发现这个值是可选的。但是如果值不是IP的话就会忽略并且下次再继续传输同样的数据就相当于一次相同的上传。我就是在改上面两条的时候测试被封1小时了