### PR TITLE
fixes get record id error.

### DIFF
--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -190,7 +190,7 @@ arDdnsCheck() {
     local hostIP=$(arIpAddress)
     echo "Updating Domain: ${2}.${1}"
     echo "hostIP: ${hostIP}"
-    lastIP=$(arDdnsInfo "$1 $2")
+    lastIP=$(arDdnsInfo $1 $2)
     if [ $? -eq 0 ]; then
         echo "lastIP: ${lastIP}"
         if [ "$lastIP" != "$hostIP" ]; then


### PR DESCRIPTION
arDdnsCheck afferent only one parameter to arDdnsInfo, so gets all records id and always use the first one.
多写了引号导致两个参数当作一个参数了