### PR TITLE
优化ID判断逻辑，以支持大于32位有限符号整数的情况(BusyBox 32bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ echo "arDdnsCheck test.org subdomain" >> ./ardnspod
 
 # 最近更新
 
+2025/8/13
+
+- 优化ID判断逻辑，以支持大于32位有限符号整数的情况(BusyBox 32bit) @Gnail89
+
 2022/5/3
 
 - 增加强制使用第三方API获取IP的选项 @Ljzd-PRO

--- a/ardnspod
+++ b/ardnspod
@@ -138,7 +138,7 @@ arDdnsIds() {
     domainId=$(arDdnsApi "Domain.Info" "domain=$2")
     domainId=$(echo $domainId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
-    if ! [ "$domainId" -gt 0 ] 2>/dev/null ;then
+    if [ "$(echo "$domainId 0" |awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
         errMsg=$(echo $domainId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
         echo "arDdnsIds - $errMsg"
         return 1
@@ -148,7 +148,7 @@ arDdnsIds() {
     recordId=$(arDdnsApi "Record.List" "domain_id=$domainId&sub_domain=$3&record_type=$1")
     recordId=$(echo $recordId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
-    if ! [ "$recordId" -gt 0 ] 2>/dev/null ;then
+    if [ "$(echo "$recordId 0" |awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
         errMsg=$(echo $recordId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
         echo "arDdnsIds - $errMsg"
         return 1

--- a/ardnspod
+++ b/ardnspod
@@ -138,7 +138,7 @@ arDdnsIds() {
     domainId=$(arDdnsApi "Domain.Info" "domain=$2")
     domainId=$(echo $domainId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
-    if [ "$(echo "$domainId 0" |awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
+    if [ "$(echo "$domainId 0" | awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
         errMsg=$(echo $domainId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
         echo "arDdnsIds - $errMsg"
         return 1
@@ -148,7 +148,7 @@ arDdnsIds() {
     recordId=$(arDdnsApi "Record.List" "domain_id=$domainId&sub_domain=$3&record_type=$1")
     recordId=$(echo $recordId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
-    if [ "$(echo "$recordId 0" |awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
+    if [ "$(echo "$recordId 0" | awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
         errMsg=$(echo $recordId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
         echo "arDdnsIds - $errMsg"
         return 1


### PR DESCRIPTION
in v6.1.x

@@ -138,7 +138,7 @@ arDdnsIds() {
    domainId=$(arDdnsApi "Domain.Info" "domain=$2")
    domainId=$(echo $domainId | sed 's/.*"id":"\([0-9]*\)".*/\1/')

\-    if ! [ "$domainId" -gt 0 ] 2>/dev/null ;then
\+    if [ "$(echo "$domainId 0" |awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
        errMsg=$(echo $domainId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
        echo "arDdnsIds - $errMsg"
        return 1
@@ -148,7 +148,7 @@ arDdnsIds() {
    recordId=$(arDdnsApi "Record.List" "domain_id=$domainId&sub_domain=$3&record_type=$1")
    recordId=$(echo $recordId | sed 's/.*"id":"\([0-9]*\)".*/\1/')

\-    if ! [ "$recordId" -gt 0 ] 2>/dev/null ;then
\+    if [ "$(echo "$recordId 0" |awk '{print ($1 > $2)}')" -eq 0 ] 2>/dev/null ;then
        errMsg=$(echo $recordId | sed 's/.*"message":"\([^\"]*\)".*/\1/')
        echo "arDdnsIds - $errMsg"
        return 1